### PR TITLE
Update claude-code-plugins post

### DIFF
--- a/_posts/2026-06-26-claude-code-plugins-and-the-trust-nobody-talks-about.adoc
+++ b/_posts/2026-06-26-claude-code-plugins-and-the-trust-nobody-talks-about.adoc
@@ -99,7 +99,7 @@ Update one without the others and something breaks: a version bump without a SHA
 Claude Code https://code.claude.com/docs/en/plugin-marketplaces#version-resolution-and-release-channels[resolves a plugin's version^] in this order: plugin.json first, then the marketplace entry, then the source SHA.
 
 If `plugin.json` sets a version, it silently wins over the marketplace entry.
-A version bump in the marketplace alone changes nothing — Claude Code still sees the old version from `plugin.json` and skips the update.
+A version bump in the marketplace alone changes nothing: Claude Code still sees the old version from `plugin.json` and skips the update.
 
 Keeping `version` only in the marketplace entry means the catalog is the single authority on what gets released.
 
@@ -147,82 +147,80 @@ togi/                              # plugin repo
 ├── hooks/
 └── .github/
     └── workflows/
-        └── create-release.yml     # tags → release → dispatch
+        └── release.yml            # tags → release → dispatch
 ----
 
 == From tag to release
 
-The release flow starts with a tag push. The tag triggers a GitHub release, which dispatches to the marketplace repo, which updates version, ref, and SHA in a single commit.
-
 === Step 1: tag and release (plugin repo)
 
-The developer pushes a tag when ready to release:
+The release flow starts with a signed annotated tag push:
 
 [source,bash]
 ----
-git tag v0.3.0
+git tag -s v0.3.0 -m "v0.3.0"
 git push origin v0.3.0
 ----
 
-A workflow triggers on the tag push:
+The tag triggers a release workflow, which dispatches to the marketplace repo:
 
 [source,yaml]
 ----
-name: Create Release
+name: Release
 
 on:
   push:
     tags: ['v*']
 
 jobs:
-  create-release:
+  release:
     runs-on: ubuntu-latest
     permissions:
       contents: write # <1>
     steps:
-      - id: tag
-        name: Extract tag
-        run: echo "value=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
-      - name: Create release
+      - id: tag
+        name: Validate and extract tag
         env:
-          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          # Only annotated tags are supported — lightweight tags provide no signing guarantee.
+          TYPE=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq '.object.type')
+          if [ "$TYPE" != "tag" ]; then
+            echo "Error: $TAG is not an annotated tag (type='$TYPE')"
+            exit 1
+          fi
+          echo "value=$TAG" >> "$GITHUB_OUTPUT"
+
+      - id: create-release
+        name: Create release
+        env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.value }}
-        run: | # <2>
-          if gh release view "$TAG" 2>/dev/null; then
-            echo "Release $TAG already exists — skipping"
-            exit 0
-          fi
-          gh release create "$TAG" --title "$TAG" --generate-notes
+        run: |
+          URL=$(gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --generate-notes)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch to marketplace
         env:
-          ICHIBA_PAT: ${{ secrets.ICHIBA_PAT }} # <3>
-          SHA: ${{ github.sha }} # <4>
-          TAG: ${{ steps.tag.outputs.value }}
-        run: | # <5>
+          ICHIBA_PAT: ${{ secrets.ICHIBA_PAT }} # <2>
+          RELEASE: ${{ steps.create-release.outputs.url }}
+        run: |
+          # Sends a `repository_dispatch` event to the marketplace repo with the release URL as the only payload.
           curl -fsSL -X POST \
             -H "Authorization: token $ICHIBA_PAT" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/gwenneg/claude-ichiba/dispatches" \
-            -d "$(jq -n \
-              --arg plugin "togi" \
-              --arg tag "$TAG" \
-              --arg sha "$SHA" \
-              '{event_type: "plugin-release", client_payload: {plugin: $plugin, tag: $tag, sha: $sha}}')"
+            -d "$(jq -n --arg release "$RELEASE" '{event_type: "plugin-release", client_payload: {release: $release}}')"
 ----
 <1> Required by `gh release create`.
-<2> Creates a GitHub release if one doesn't already exist for this tag.
-<3> See <<The bridge: a fine-grained PAT>>.
-<4> Works because `git tag v0.3.0` creates a lightweight tag, where `github.sha` is the commit SHA.
-For annotated tags (`git tag -a`), `github.sha` may return the tag object SHA instead.
-Stick to lightweight tags, or resolve with `git rev-parse "$TAG^{commit}"`.
-<5> Sends a `repository_dispatch` to the marketplace repo with the plugin name, tag, and commit SHA.
+<2> See <<The bridge: a fine-grained PAT>>.
 
 === Step 2: update the catalog (marketplace repo)
 
-The marketplace repo receives the dispatch and updates `marketplace.json`:
+The marketplace repo receives the dispatch and resolves the plugin, tag, and commit SHA from the release URL.
+It then opens a pull request so every catalog update can be reviewed before it reaches `main`.
 
 [source,yaml]
 ----
@@ -237,39 +235,79 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # <1>
+      pull-requests: write # <2>
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7 <2>
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0 <3>
 
-      - name: Update marketplace.json
+      - id: update-marketplace
+        name: Update marketplace.json
         env:
-          PLUGIN: ${{ github.event.client_payload.plugin }}
-          SHA: ${{ github.event.client_payload.sha }}
-          TAG: ${{ github.event.client_payload.tag }}
-        run: | # <3>
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE: ${{ github.event.client_payload.release }}
+        run: |
+
+          # Resolve the plugin name by matching the release URL against `source.repo` in marketplace.json.
+          PLUGIN=$(jq -r --arg u "$RELEASE" \
+            '.plugins[] | select(("https://github.com/" + .source.repo + "/") as $prefix | $u | startswith($prefix)) | .name' \
+            .claude-plugin/marketplace.json)
+          if [ -z "$PLUGIN" ]; then
+            echo "Error: no plugin matched $RELEASE"
+            exit 1
+          fi
+
+          # Extract tag and repo from the release URL (https://github.com/owner/repo/releases/tag/vX.Y.Z).
+          TAG=$(basename "$RELEASE")
+          REPO=$(echo "$RELEASE" | cut -d'/' -f4-5)
+
+          # Resolve the commit SHA from the annotated tag — two calls needed to dereference the tag object.
+          REF=$(gh api "repos/$REPO/git/ref/tags/$TAG")
+          if [ "$(echo "$REF" | jq -r '.object.type')" != "tag" ]; then
+            echo "Error: $TAG is not an annotated tag"
+            exit 1
+          fi
+          SHA=$(gh api "repos/$REPO/git/tags/$(echo "$REF" | jq -r '.object.sha')" --jq '.object.sha')
+
+          # Update version, ref, and sha for the matched plugin. Uses a temp file because jq cannot read and write the same file.
           jq --arg p "$PLUGIN" --arg v "${TAG#v}" --arg r "$TAG" --arg s "$SHA" \
             '(.plugins[] | select(.name == $p)) |= (.version = $v | .source.ref = $r | .source.sha = $s)' \
             .claude-plugin/marketplace.json > /tmp/marketplace.json
           mv /tmp/marketplace.json .claude-plugin/marketplace.json
 
-      - name: Commit
+          echo "plugin=$PLUGIN" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create branch and PR
         env:
-          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PLUGIN: ${{ github.event.client_payload.plugin }}
-          TAG: ${{ github.event.client_payload.tag }}
-        run: | # <4>
-          FILE_SHA=$(gh api "repos/$GH_REPO/contents/.claude-plugin/marketplace.json" --jq '.sha')
-          gh api "repos/$GH_REPO/contents/.claude-plugin/marketplace.json" \
+          PLUGIN: ${{ steps.update-marketplace.outputs.plugin }}
+          RELEASE: ${{ github.event.client_payload.release }}
+          TAG: ${{ steps.update-marketplace.outputs.tag }}
+        run: |
+          BRANCH="release/$PLUGIN-$TAG"
+
+          # Create the release branch from the current HEAD of main.
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+            --method POST \
+            -f "ref=refs/heads/$BRANCH" \
+            -f "sha=$(git rev-parse HEAD)"
+
+          # Commit the updated marketplace.json via the Contents API, which produces a signed commit.
+          gh api "repos/$GITHUB_REPOSITORY/contents/.claude-plugin/marketplace.json" \
             --method PUT \
             -f "message=release: $PLUGIN $TAG" \
             -f "content=$(base64 -w 0 < .claude-plugin/marketplace.json)" \
-            -f "sha=$FILE_SHA"
+            -f "sha=$(git rev-parse HEAD:.claude-plugin/marketplace.json)" \
+            -f "branch=$BRANCH"
+
+          gh pr create \
+            --title "release: $PLUGIN $TAG" \
+            --body "[$TAG]($RELEASE)" \
+            --base main \
+            --head "$BRANCH"
 ----
-<1> Required to commit `marketplace.json` via the GitHub API.
-<2> Security tip: always pin GitHub Actions to a commit SHA, not a tag. The same tag-rewriting risk described earlier applies to actions too.
-<3> Finds the plugin by name in `marketplace.json` and updates version, ref, and SHA in one pass.
-<4> Commits the updated file to `main` via the GitHub API.
-Commits made this way are automatically signed by GitHub.
+<1> Required to create the release branch and commit `marketplace.json`.
+<2> Required to create the pull request.
+<3> Security tip: always pin GitHub Actions to a commit SHA, not a tag. The same tag-rewriting risk described earlier applies to actions too.
 
 The triple update (`version`, `source.ref`, `source.sha`) happens in one `jq` call and lands in one commit, so the catalog is never in a half-updated state.
 
@@ -288,9 +326,12 @@ Store it as a repository secret (e.g. `ICHIBA_PAT`) in the plugin repo.
 
 [WARNING]
 ====
-This PAT is the single most sensitive piece in the pipeline.
-Anyone who obtains it can call the dispatch API directly and push an arbitrary SHA to `marketplace.json`, bypassing the entire tag-based release flow.
-Set an expiration, rotate it regularly, monitor the audit log for unexpected dispatch events, and revoke immediately if the plugin repo's secrets are compromised.
+This PAT is the most sensitive piece in the pipeline.
+Anyone who obtains it can trigger a dispatch with an arbitrary release URL, opening a rogue pull request against the marketplace repo.
+They cannot inject an arbitrary SHA: the marketplace workflow resolves the commit SHA directly from the GitHub API.
+And they cannot write to `main` directly: the dispatch only opens a PR, which still requires review and approval.
+The risk is noise and distraction, not silent code substitution.
+That said: set an expiration, rotate it regularly, monitor the audit log for unexpected dispatch events, and revoke immediately if the plugin repo's secrets are compromised.
 ====
 
 == What users see
@@ -326,16 +367,16 @@ The threat model changes significantly: the refresh becomes silent, not delibera
 Adding a new plugin now requires three simple steps:
 
 1. Create the plugin repo with its own `.claude-plugin/plugin.json`, skills, hooks, etc.
-2. Add a `create-release.yml` workflow that dispatches to the marketplace repo (same template, different plugin name).
+2. Add a `release.yml` workflow that dispatches to the marketplace repo. The template can be copied verbatim: the marketplace resolves the plugin name from the release URL, so nothing needs to be hardcoded per plugin.
 3. Add an entry to `marketplace.json` in the marketplace repo.
 
-The marketplace workflow already matches plugins by name (`select(.name == $p)`), so it handles multiple plugins without changes.
+The marketplace workflow matches plugins by `source.repo`, so it handles multiple plugins without changes.
 
 == Known gaps
 
 This setup is the best I could do with what Claude Code and GitHub offer today. It's not airtight.
 
-- **The catalog lives on `main`.** When users refresh, they pull the current `marketplace.json` from `main`. A compromised `main` branch in the marketplace repo ships a rewritten SHA on the next refresh. Branch protection, required reviews, and signed commits reduce this exposure but do not eliminate it.
+- **The catalog lives on `main`.** Every release goes through a pull request before landing. But the branch is the final source of truth: a bad commit that reaches it ships a rewritten SHA on the next refresh. Branch protection, required reviews, and required signed commits reduce this exposure but do not eliminate it.
 - **No update notification.** Claude Code does not tell users when a new version exists. They have to watch the plugin repo for releases and refresh manually.
 - **No platform-level signing.** Claude Code has no plugin signature verification. SHA pinning gives tamper-evidence (you can verify what you run), but not tamper-prevention (nothing stops a bad SHA from being written to the catalog if `main` is compromised). That gap closes only when Claude Code adds signing.
 


### PR DESCRIPTION
## What changed

Updates to `_posts/2026-06-26-claude-code-plugins-and-the-trust-nobody-talks-about.adoc` reflecting the reworked release pipeline.

### Release workflow (plugin repo)

- Renamed workflow file from `create-release.yml` to `release.yml` and job from `create-release` to `release`
- Tags must now be signed annotated tags (`git tag -s`) — the workflow validates this before proceeding
- Removed the "skip if release already exists" guard (idempotency is no longer needed)
- Dispatch payload simplified to a single `release` URL; the marketplace resolves plugin name, tag, and SHA from it
- Dropped callout explaining `github.sha` behaviour on lightweight vs annotated tags (no longer relevant)

### Marketplace workflow (claude-ichiba)

- Added `pull-requests: write` permission
- Marketplace now resolves the plugin by matching the release URL against `source.repo` instead of receiving the plugin name in the payload
- SHA is resolved server-side from the annotated tag object (two-step dereference via the GitHub API), removing reliance on `github.sha`
- Instead of committing directly to `main`, the workflow now opens a pull request so every catalog update can be reviewed before it lands
- Hardcoded plugin name removed from dispatch payload — the template can be copied verbatim for any plugin

### PAT warning

Revised to reflect the reduced blast radius: a stolen PAT can open a rogue PR but cannot inject an arbitrary SHA (resolved from the GitHub API) and cannot write to `main` directly (PR review is still required).

### Known gaps

Updated the `main`-branch gap to reflect that releases now go through a PR before landing.

### Misc

- Dash replaced with colon in one sentence for consistency
- "Adding a second plugin" section updated to match the new plugin-name resolution logic