### PR TITLE
blog: fix "What users see" section in claude-code-plugins post

### DIFF
--- a/_posts/2026-06-26-claude-code-plugins-and-the-trust-nobody-talks-about.adoc
+++ b/_posts/2026-06-26-claude-code-plugins-and-the-trust-nobody-talks-about.adoc
@@ -295,22 +295,23 @@ Set an expiration, rotate it regularly, monitor the audit log for unexpected dis
 
 == What users see
 
-With this release pipeline, nothing changes for users.
-That was the whole point.
-They still install with two commands:
+None of the pipeline complexity surfaces to users.
+Their side stays simple.
+Install with:
 
 [source]
 ----
 /plugin marketplace add gwenneg/claude-ichiba
 /plugin install togi@claude-ichiba
+/reload-plugins
 ----
 
 And update with:
 
 [source]
 ----
-/plugin marketplace update
-/plugin update togi@claude-ichiba
+/plugin marketplace update claude-ichiba
+/reload-plugins
 ----
 
 [WARNING]


### PR DESCRIPTION
## Summary

- Fix install and update commands to match the ai-mentor README: add `/reload-plugins` after install, replace `/plugin update togi@claude-ichiba` with `/plugin marketplace update claude-ichiba` + `/reload-plugins`
- Rewrite the intro paragraph to drop the misleading "nothing changes" / "still" framing (there was no prior user experience to compare against) — new framing makes the real point: the pipeline complexity is invisible to users

🤖 Generated with [Claude Code](https://claude.com/claude-code)