### PR TITLE
blog: tighten "Adding a second plugin" section

### DIFF
--- a/_posts/2026-06-26-claude-code-plugins-and-the-trust-nobody-talks-about.adoc
+++ b/_posts/2026-06-26-claude-code-plugins-and-the-trust-nobody-talks-about.adoc
@@ -363,13 +363,9 @@ The threat model changes significantly: the refresh becomes silent, not delibera
 
 == Adding a second plugin
 
-Adding a new plugin now requires three simple steps:
-
 1. Create the plugin repo with its own `.claude-plugin/plugin.json`, skills, hooks, etc.
-2. Add a `release.yml` workflow that dispatches to the marketplace repo. The template can be copied verbatim: the marketplace resolves the plugin name from the release URL, so nothing needs to be hardcoded per plugin.
+2. Copy `release.yml` verbatim: the marketplace resolves the plugin name from the release URL, so nothing is hardcoded per plugin.
 3. Add an entry to `marketplace.json` in the marketplace repo.
-
-The marketplace workflow matches plugins by `source.repo`, so it handles multiple plugins without changes.
 
 == Known gaps
 


### PR DESCRIPTION
## Summary

- Drop the redundant "Adding a new plugin now requires three simple steps" intro (obvious from the numbered list)
- Tighten item 2: "Copy `release.yml` verbatim" is more direct than "Add a `release.yml` workflow that dispatches to the marketplace repo. The template can be copied verbatim"
- Drop the trailing sentence about `source.repo` matching (already implied by item 2 saying nothing is hardcoded per plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)