### PR TITLE
fix: add logger gem for Ruby 4.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 4.4.1'
+gem 'logger'
 
 # The plugins order matters! See https://github.com/asciidoctor/jekyll-asciidoc?tab=readme-ov-file#plugin-ordering
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,9 +13,9 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
-    google-protobuf (4.29.3-x86_64-linux)
+    google-protobuf (4.33.6)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -65,6 +65,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -93,6 +94,7 @@ DEPENDENCIES
   jekyll-feed (~> 0.17.0)
   jekyll-include-cache (~> 0.2.1)
   jekyll-remote-theme (~> 0.4.3)
+  logger
 
 BUNDLED WITH
    2.5.18


### PR DESCRIPTION
## Summary

- Adds `logger` as an explicit Gemfile dependency
- Jekyll 4.4.1 requires `logger` but doesn't declare it in its gemspec
- Ruby 4.0 removed `logger` from the default gems, causing `bundle exec jekyll serve` to fail with a `LoadError`

## Test plan

- [ ] `bundle install` succeeds
- [ ] `bundle exec jekyll serve` starts without errors