### PR TITLE
chore: bump minimal-mistakes to 4.28.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,7 +49,7 @@ footer:
 locale: en-US
 minimal_mistakes_skin: default
 og_image: /assets/images/og_image.png
-remote_theme: mmistakes/minimal-mistakes@4.26.2
+remote_theme: mmistakes/minimal-mistakes@4.28.0
 repository: gwenneg/gwenneg.github.io
 search: true
 show_excerpts: true

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -62,12 +62,6 @@
 .conum[data-value] + b {
     display: none;
 }
-.clipboard-copy-button {
-    right: 5.5em !important;
-}
-.clipboard-copy-button > span {
-    margin-left: 1.2em !important;
-}
 .highlight {
     padding: 20px;
 }


### PR DESCRIPTION
## Summary

- Upgrades `remote_theme` from `mmistakes/minimal-mistakes@4.26.2` to `@4.28.0`
- Removes the `.clipboard-copy-button` CSS overrides that were added as a temporary workaround for a layout issue now fixed upstream

## Test plan

- [ ] Site builds and deploys correctly via GitHub Pages
- [ ] Code block clipboard button renders without layout issues
- [ ] No visual regressions on post pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)