### PR TITLE
blog: add release-subscription tip to AI Mentor post

### DIFF
--- a/_posts/2026-07-13-which-80-percent-of-claude-code-are-you-missing.adoc
+++ b/_posts/2026-07-13-which-80-percent-of-claude-code-are-you-missing.adoc
@@ -219,7 +219,7 @@ Either enable auto-update once (`/plugin` -> Marketplaces -> claude-ichiba), or 
 
 [TIP]
 ====
-Skip the manual check: https://github.com/gwenneg/ai-mentor/subscription[subscribe to releases^] and GitHub will tell you the moment a new version ships, so you know exactly when to run the update above.
+Not sure when to update? https://github.com/gwenneg/ai-mentor/subscription[Subscribe to releases^] and GitHub will tell you the moment a new version ships, so you know exactly when to run the update above.
 ====
 
 If you try it, start with the problem you are actually dealing with today.

--- a/_posts/2026-07-13-which-80-percent-of-claude-code-are-you-missing.adoc
+++ b/_posts/2026-07-13-which-80-percent-of-claude-code-are-you-missing.adoc
@@ -217,6 +217,11 @@ Either enable auto-update once (`/plugin` -> Marketplaces -> claude-ichiba), or 
 /reload-plugins
 ----
 
+[TIP]
+====
+Skip the manual check: https://github.com/gwenneg/ai-mentor/subscription[subscribe to releases^] and GitHub will tell you the moment a new version ships, so you know exactly when to run the update above.
+====
+
 If you try it, start with the problem you are actually dealing with today.
 The plugin did its job when the answer contains something you didn't know existed.
 And when it doesn't, tell the mentor: it records what you already know and does better next time.


### PR DESCRIPTION
## Summary
- Adds a TIP admonition pointing readers at https://github.com/gwenneg/ai-mentor/subscription so they can subscribe to release notifications instead of checking manually before running the marketplace update commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)